### PR TITLE
fix typo preventing event handler firing

### DIFF
--- a/lib/garageserver.io.js
+++ b/lib/garageserver.io.js
@@ -91,8 +91,8 @@ GarageServer.prototype.registerSocketEvents = function (options) {
             if (options.logging) {
                 console.log('garageserver.io:: event ' + data);
             }
-            if (options.OnEvent) {
-                options.OnEvent(data);
+            if (options.onEvent) {
+                options.onEvent(data);
             }
         });
     });


### PR DESCRIPTION
`options.OnEvent` is documented as `options.onEvent`. Assuming consistency with other events, and `_options.onEvent` was intended, fixing typo here instead of in [docs](https://github.com/jbillmann/GarageServer.IO/blob/master/documentation/ServerAPI.md#server-options).